### PR TITLE
V1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,8 @@ repositories {
 
 dependencies {
     compile "org.apache.ant:ant:1.9.4"
-    compile "junit:junit:4.11"
-    compile "log4j:log4j:1.2.17"
-    compile "com.google.code.gson:gson:2.2.4"
-    compile "commons-lang:commons-lang:2.6"
-    compile "commons-io:commons-io:2.4"
-    compile "org.apache.httpcomponents:httpclient:4.2.6", "org.apache.httpcomponents:httpcore:4.2.5", "org.apache.httpcomponents:httpmime:4.2.6"
+    compile "com.netflix.feign:feign-core:8.17.0"
+    compile "com.netflix.feign:feign-jackson:8.17.0"
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: "java"
 apply plugin: "fatjar"
 
-version "1.2"
+version "1.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/loadster/sdk/client/WorkbenchApiClient.java
+++ b/src/main/java/loadster/sdk/client/WorkbenchApiClient.java
@@ -1,113 +1,81 @@
 package loadster.sdk.client;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import feign.*;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
 import loadster.sdk.exceptions.ApiException;
-import loadster.sdk.types.ErrorDetail;
-import loadster.sdk.types.Reference;
+import loadster.sdk.types.Scenario;
+import loadster.sdk.types.Test;
 import loadster.sdk.types.TestStatistics;
 import loadster.sdk.types.TestStatus;
-import org.apache.http.HttpResponse;
-import org.apache.http.ProtocolException;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 
 /**
  * Simplified client interface for the Workbench API.
  */
 public class WorkbenchApiClient {
-    private String baseUrl;
-    private String apiKey;
+    private WorkbenchApi jsonApi;
 
-    private DefaultHttpClient httpClient = new DefaultHttpClient();
-    private Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'").create();
-
-    public WorkbenchApiClient(String host, int port, String apiKey) {
-        this.baseUrl = "http://" + host + ":" + port;
-        this.apiKey = apiKey;
+    public WorkbenchApiClient(final String host, final int port, final String apiKey) {
+        jsonApi = Feign.builder().decoder(new JacksonDecoder()).encoder(new JacksonEncoder()).requestInterceptor(new RequestInterceptor() {
+            @Override
+            public void apply(RequestTemplate requestTemplate) {
+                requestTemplate.query("apiKey", apiKey);
+            }
+        }).target(WorkbenchApi.class, "http://" + host + ":" + port);
     }
 
     /**
-     * Attempts to start a test for a scenario, such as <code>/projects/1/scenarios/3</code>.
+     * Attempts to start a test for a scenario.
      */
-    public Reference startTest(String scenarioUri) throws ApiException, IOException, ProtocolException {
-        HttpPost post = new HttpPost(baseUrl + scenarioUri + "/tests?apiKey=" + apiKey);
-        HttpResponse response = httpClient.execute(post);
-        Reader reader = new InputStreamReader(response.getEntity().getContent(), "UTF-8");
-        int status = response.getStatusLine().getStatusCode();
+    public Test startTest(Scenario scenario) throws ApiException, IOException {
+        Test test = jsonApi.startTest(scenario.getProjectId(), scenario.getId());
 
-        if (status == 201) {
-            return gson.fromJson(reader, Reference.class);
-        } else if (status == 403) {
-            EntityUtils.consumeQuietly(response.getEntity());
+        // TODO - the API should be including these fields in the response
+        test.setProjectId(scenario.getProjectId());
+        test.setScenarioId(scenario.getId());
 
-            throw new ApiException(gson.fromJson(reader, ErrorDetail.class));
-        } else {
-            EntityUtils.consumeQuietly(response.getEntity());
-
-            throw new ApiException(response.getStatusLine().toString());
-        }
+        return test;
     }
 
     /**
      * Gets up-to-date status on a test.
      */
-    public TestStatus getTestStatus(Reference test) throws ApiException, IOException, ProtocolException {
-        HttpGet request = new HttpGet(test.getHref() + "/status?apiKey=" + apiKey);
-        HttpResponse response = httpClient.execute(request);
-        Reader reader = new InputStreamReader(response.getEntity().getContent(), "UTF-8");
-        int status = response.getStatusLine().getStatusCode();
-
-        if (status == 200) {
-            return gson.fromJson(reader, TestStatus.class);
-        } else {
-            EntityUtils.consumeQuietly(response.getEntity());
-
-            throw new ApiException(response.getStatusLine().toString());
-        }
+    public TestStatus getTestStatus(Test test) throws ApiException, IOException {
+        return jsonApi.getTestStatus(test.getProjectId(), test.getScenarioId(), test.getId());
     }
 
     /**
      * Fetches an HTML test report for a test. The test has to be finished or this will fail.
      */
-    public InputStream getTestReport(Reference test) throws ApiException, IOException, ProtocolException {
-        HttpGet request = new HttpGet(test.getHref() + "/report?apiKey=" + apiKey);
-        HttpResponse response = httpClient.execute(request);
-        int status = response.getStatusLine().getStatusCode();
-
-        if (status == 200) {
-            return response.getEntity().getContent();
-        } else {
-            EntityUtils.consumeQuietly(response.getEntity());
-
-            throw new ApiException(response.getStatusLine().toString());
-        }
+    public InputStream getTestReport(Test test) throws ApiException, IOException {
+        return jsonApi.getTestReport(test.getProjectId(), test.getScenarioId(), test.getId()).body().asInputStream();
     }
 
     /**
      * Fetches statistics for a test. The test has to be finished or this will fail.
      */
-    public TestStatistics getTestStatistics(Reference test) throws ApiException, IOException, ProtocolException {
-        HttpGet request = new HttpGet(test.getHref() + "/report?apiKey=" + apiKey);
+    public TestStatistics getTestStatistics(Test test) throws ApiException, IOException {
+        return jsonApi.getTestStatistics(test.getProjectId(), test.getScenarioId(), test.getId());
+    }
 
-        request.setHeader("Accept", "application/json");
+    private interface WorkbenchApi {
+        @RequestLine("POST /projects/{projectId}/scenarios/{scenarioId}/tests")
+        @Headers("Accept: application/json")
+        Test startTest(@Param("projectId") String projectId, @Param("scenarioId") String scenarioId);
 
-        HttpResponse response = httpClient.execute(request);
-        int status = response.getStatusLine().getStatusCode();
+        @RequestLine("GET /projects/{projectId}/scenarios/{scenarioId}/tests/{testId}/status")
+        @Headers("Accept: application/json")
+        TestStatus getTestStatus(@Param("projectId") String projectId, @Param("scenarioId") String scenarioId, @Param("testId") String testId);
 
-        if (status == 200) {
-            return gson.fromJson(new InputStreamReader(response.getEntity().getContent()), TestStatistics.class);
-        } else {
-            EntityUtils.consumeQuietly(response.getEntity());
+        @RequestLine("GET /projects/{projectId}/scenarios/{scenarioId}/tests/{testId}/report")
+        @Headers("Accept: application/json")
+        TestStatistics getTestStatistics(@Param("projectId") String projectId, @Param("scenarioId") String scenarioId, @Param("testId") String testId);
 
-            throw new ApiException(response.getStatusLine().toString());
-        }
+        @RequestLine("GET /projects/{projectId}/scenarios/{scenarioId}/tests/{testId}/report")
+        @Headers("Accept: text/html")
+        Response getTestReport(@Param("projectId") String projectId, @Param("scenarioId") String scenarioId, @Param("testId") String testId);
     }
 }

--- a/src/main/java/loadster/sdk/client/WorkbenchApiClient.java
+++ b/src/main/java/loadster/sdk/client/WorkbenchApiClient.java
@@ -5,8 +5,8 @@ import com.google.gson.GsonBuilder;
 import loadster.sdk.exceptions.ApiException;
 import loadster.sdk.types.ErrorDetail;
 import loadster.sdk.types.Reference;
+import loadster.sdk.types.TestStatistics;
 import loadster.sdk.types.TestStatus;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolException;
 import org.apache.http.client.methods.HttpGet;
@@ -84,6 +84,26 @@ public class WorkbenchApiClient {
 
         if (status == 200) {
             return response.getEntity().getContent();
+        } else {
+            EntityUtils.consumeQuietly(response.getEntity());
+
+            throw new ApiException(response.getStatusLine().toString());
+        }
+    }
+
+    /**
+     * Fetches statistics for a test. The test has to be finished or this will fail.
+     */
+    public TestStatistics getTestStatistics(Reference test) throws ApiException, IOException, ProtocolException {
+        HttpGet request = new HttpGet(test.getHref() + "/report?apiKey=" + apiKey);
+
+        request.setHeader("Accept", "application/json");
+
+        HttpResponse response = httpClient.execute(request);
+        int status = response.getStatusLine().getStatusCode();
+
+        if (status == 200) {
+            return gson.fromJson(new InputStreamReader(response.getEntity().getContent()), TestStatistics.class);
         } else {
             EntityUtils.consumeQuietly(response.getEntity());
 

--- a/src/main/java/loadster/sdk/tasks/RunTest.java
+++ b/src/main/java/loadster/sdk/tasks/RunTest.java
@@ -2,50 +2,49 @@ package loadster.sdk.tasks;
 
 import loadster.sdk.client.WorkbenchApiClient;
 import loadster.sdk.exceptions.ApiException;
-import loadster.sdk.types.Reference;
+import loadster.sdk.types.Scenario;
+import loadster.sdk.types.Test;
 import loadster.sdk.types.TestStatus;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.http.ProtocolException;
-import org.apache.log4j.Logger;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Simple task to kick off a test via the Loadster Workbench web service, monitor it while it runs, and automatically
  * download a test report once it is finished.
  */
 public class RunTest implements Runnable {
-    private static final Logger log = Logger.getLogger(RunTest.class);
-
     private WorkbenchApiClient client;
-    private String scenarioUri;
+    private String projectId;
+    private String scenarioId;
     private String testReportOutputFile;
 
-    public RunTest(String apiHost, int apiPort, String apiKey, String scenarioUri, String testReportOutputFile) {
+    public RunTest(String apiHost, int apiPort, String apiKey, String projectId, String scenarioId, String testReportOutputFile) {
         this.client = new WorkbenchApiClient(apiHost, apiPort, apiKey);
-        this.scenarioUri = scenarioUri;
+        this.projectId = projectId;
+        this.scenarioId = scenarioId;
         this.testReportOutputFile = testReportOutputFile;
     }
 
     public void run() {
         try {
-            Reference ref = client.startTest(scenarioUri);
+            Scenario scenario = new Scenario(projectId, scenarioId);
+            Test test = client.startTest(scenario);
 
-            log.info("Started test " + ref.getId() + " for scenario " + scenarioUri);
+            log("Started test " + test.getId() + " for scenario " + scenarioId + " of project " + projectId);
 
-            waitForTestToStart(ref);
-            pollWhileTestIsRunning(ref);
+            waitForTestToStart(test);
+            pollWhileTestIsRunning(test);
 
-            log.info("Attempting to fetch the test report...");
+            log("Attempting to fetch the test report...");
 
-            IOUtils.copy(waitForTestReport(ref), new FileOutputStream(testReportOutputFile));
+            copy(waitForTestReport(test), new FileOutputStream(testReportOutputFile));
 
-            log.info("Saved test report to " + testReportOutputFile);
+            log("Saved test report to " + testReportOutputFile);
         } catch (Exception e) {
-            log.error(e);
+            log(e.getMessage());
 
             System.exit(2);
         }
@@ -53,44 +52,60 @@ public class RunTest implements Runnable {
         System.exit(0);
     }
 
-    private void waitForTestToStart(Reference ref) throws ApiException, InterruptedException, IOException, ProtocolException {
+    private void waitForTestToStart(Test test) throws ApiException, InterruptedException, IOException {
         for (int i = 0; i < 60; i++) {
             Thread.sleep(10000);
 
-            TestStatus status = client.getTestStatus(ref);
+            TestStatus status = client.getTestStatus(test);
 
             if (status.getStatus().equals(TestStatus.RUNNING)) {
-                log.info("Test is up and running!");
+                log("Test is up and running!");
 
                 break;
             } else {
-                log.debug("Waiting for test to start...");
+                log("Waiting for test to start...");
             }
         }
     }
 
-    private void pollWhileTestIsRunning(Reference ref) throws ApiException, InterruptedException, IOException, ProtocolException {
-        for (TestStatus status = client.getTestStatus(ref); status.getStatus().equals(TestStatus.RUNNING); status = client.getTestStatus(ref)) {
-            log.info("Test is running (v-users=" + status.getRunningUsers() + ")");
+    private void pollWhileTestIsRunning(Test test) throws ApiException, InterruptedException, IOException {
+        for (TestStatus status = client.getTestStatus(test); status.getStatus().equals(TestStatus.RUNNING); status = client.getTestStatus(test)) {
+            log("Test is running (v-users=" + status.getRunningUsers() + ")");
 
             Thread.sleep(10000);
         }
 
-        log.info("Test is finished!");
+        log("Test is finished!");
     }
 
-    private InputStream waitForTestReport(Reference ref) throws ApiException {
+    private InputStream waitForTestReport(Test test) throws ApiException {
         for (int i = 0; i < 60; i++) {
             try {
                 Thread.sleep(3000);
 
-                return client.getTestReport(ref);
+                return client.getTestReport(test);
             } catch (Exception e) {
-                log.info("Waiting for the test report to become available...");
+                log("Waiting for the test report to become available...");
             }
         }
 
         throw new ApiException("Failed to load the test report!");
+    }
+
+    private static void log(String message) {
+        System.out.println(message);
+    }
+
+    private static void copy(InputStream source, OutputStream destination) throws IOException {
+        byte[] buf = new byte[2048];
+        int x;
+
+        while ((x = source.read(buf)) != -1) {
+            destination.write(buf, 0, x);
+        }
+
+        source.close();
+        destination.close();
     }
 
     public static void main(String[] args) {
@@ -98,17 +113,17 @@ public class RunTest implements Runnable {
         String apiHost = System.getProperty("loadster.api.host");
         int apiPort = Integer.parseInt(System.getProperty("loadster.api.port", "1999"));
 
-        if (StringUtils.isEmpty(apiKey)) {
+        if (apiKey == null || apiKey.length() == 0) {
             System.err.println("API key not set! Use -Dloadster.api.key=changeme");
             System.exit(1);
-        } else if (StringUtils.isEmpty(apiHost)) {
+        } else if (apiHost == null || apiHost.length() == 0) {
             System.err.println("API host not set! Use -Dloadster.api.host=10.0.0.1");
             System.exit(1);
-        } else if (args.length < 2) {
-            System.err.println("Usage: " + RunTest.class.getName() + " /projects/00001/scenarios/00001 report.html");
+        } else if (args.length < 3) {
+            System.err.println("Usage: " + RunTest.class.getName() + " <projectId> <scenarioId> <testReportOutputFile>");
             System.exit(1);
         }
 
-        new RunTest(apiHost, apiPort, apiKey, args[0], args[1]).run();
+        new RunTest(apiHost, apiPort, apiKey, args[0], args[1], args[2]).run();
     }
 }

--- a/src/main/java/loadster/sdk/tasks/ant/RunTestAntTask.java
+++ b/src/main/java/loadster/sdk/tasks/ant/RunTestAntTask.java
@@ -1,9 +1,6 @@
 package loadster.sdk.tasks.ant;
 
 import loadster.sdk.tasks.RunTest;
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
@@ -13,36 +10,36 @@ import java.io.File;
  * Ant task to run a test.
  */
 public class RunTestAntTask extends Task {
-    private static final Logger log = Logger.getLogger(RunTestAntTask.class);
-
     private String apiHost = "localhost";
     private int apiPort = 1999;
     private String apiKey = null;
-    private String scenarioPath = null;
+    private String projectId;
+    private String scenarioId = null;
     private File toFile = null;
 
     /**
      * The main execute method. If all the right attributes are set, this runs the test.
      */
     public void execute() {
-        Logger.getRootLogger().getAppender("console").setLayout(new PatternLayout("%m%n"));
-        Logger.getRootLogger().addAppender(new ConsoleAppender());
-
         if (apiKey == null || apiKey.length() == 0) {
-            throw new BuildException("Parameter 'apikey' is required!");
+            throw new BuildException("Parameter 'apiKey' is required!");
         }
 
-        if (scenarioPath == null || scenarioPath.length() == 0) {
-            throw new BuildException("Parameter 'scenariopath' is required! Example /projects/00001/scenarios/00003");
+        if (projectId == null || projectId.length() == 0) {
+            throw new BuildException("Parameter 'projectId' is required!");
+        }
+
+        if (scenarioId == null || scenarioId.length() == 0) {
+            throw new BuildException("Parameter 'scenarioId' is required!");
         }
 
         if (toFile == null) {
-            throw new BuildException("Parameter 'tofile' is required! This is the destination where the test report should be saved.");
+            throw new BuildException("Parameter 'toFile' is required! This is the destination where the test report should be saved.");
         }
 
-        log.info("Preparing to run scenario " + scenarioPath + " on " + apiHost + " port " + apiPort + "...");
+        System.out.println("Preparing to run scenario " + scenarioId + " of project " + projectId + " on " + apiHost + " port " + apiPort + "...");
 
-        new RunTest(apiHost, apiPort, apiKey, scenarioPath, toFile.getAbsolutePath()).run();
+        new RunTest(apiHost, apiPort, apiKey, projectId, scenarioId, toFile.getAbsolutePath()).run();
     }
 
     public String getApiHost() {
@@ -69,12 +66,20 @@ public class RunTestAntTask extends Task {
         this.apiKey = apiKey;
     }
 
-    public String getScenarioPath() {
-        return scenarioPath;
+    public String getProjectId() {
+        return projectId;
     }
 
-    public void setScenarioPath(String scenarioPath) {
-        this.scenarioPath = scenarioPath;
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getScenarioId() {
+        return scenarioId;
+    }
+
+    public void setScenarioId(String scenarioId) {
+        this.scenarioId = scenarioId;
     }
 
     public File getToFile() {

--- a/src/main/java/loadster/sdk/types/Scenario.java
+++ b/src/main/java/loadster/sdk/types/Scenario.java
@@ -9,11 +9,20 @@ import java.util.List;
  */
 public class Scenario {
     private String id;
+    private String projectId;
     private String name;
     private Date createdDate;
     private Date modifiedDate;
     private List<Population> populations = new ArrayList<Population>();
     private List<Reference> tests = new ArrayList<Reference>();
+
+    public Scenario() {
+    }
+
+    public Scenario(String projectId, String scenarioId) {
+        this.projectId = projectId;
+        this.id = scenarioId;
+    }
 
     public String getId() {
         return id;
@@ -21,6 +30,14 @@ public class Scenario {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
     }
 
     public String getName() {

--- a/src/main/java/loadster/sdk/types/Test.java
+++ b/src/main/java/loadster/sdk/types/Test.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 public class Test {
     private String id;
+    private String projectId;
+    private String scenarioId;
     private String name;
     private Date createdDate;
     private Date modifiedDate;
@@ -23,6 +25,22 @@ public class Test {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getScenarioId() {
+        return scenarioId;
+    }
+
+    public void setScenarioId(String scenarioId) {
+        this.scenarioId = scenarioId;
     }
 
     public String getName() {

--- a/src/main/java/loadster/sdk/types/TestStatistics.java
+++ b/src/main/java/loadster/sdk/types/TestStatistics.java
@@ -1,0 +1,252 @@
+package loadster.sdk.types;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestStatistics {
+    private List<String> urlsByTotalResponseTime;
+
+    private Map<String, Integer> pageCount = new HashMap<String, Integer>();
+    private Map<String, Double> totalResponseTimes = new HashMap<String, Double>();
+    private Map<String, Double> maxResponseTimes = new HashMap<String, Double>();
+    private Map<String, Double> avgResponseTimes = new HashMap<String, Double>();
+    private Map<String, Double> minResponseTimes = new HashMap<String, Double>();
+    private Map<String, HashMap<String, Integer>> pageErrorCount = new HashMap<String, HashMap<String, Integer>>();
+    private Map<String, String> jsonDataByProvider = new HashMap<String, String>();
+    private long totalHits;
+    private long totalPages;
+    private long totalErrors;
+    private long totalIterations;
+    private long totalBytesTransferred;
+    private long totalBytesUploaded;
+    private long totalBytesDownloaded;
+    private double maxPagesPerSecond;
+    private double avgPagesPerSecond;
+    private double minPagesPerSecond;
+    private double maxHitsPerSecond;
+    private double avgHitsPerSecond;
+    private double minHitsPerSecond;
+    private double maxBytesPerSecond;
+    private double avgBytesPerSecond;
+    private double minBytesPerSecond;
+    private double responseTimeAvg;
+    private double responseTimeP90;
+    private double responseTimeP80;
+
+    public List<String> getUrlsByTotalResponseTime() {
+        return urlsByTotalResponseTime;
+    }
+
+    public void setUrlsByTotalResponseTime(List<String> urlsByTotalResponseTime) {
+        this.urlsByTotalResponseTime = urlsByTotalResponseTime;
+    }
+
+    public Map<String, Integer> getPageCount() {
+        return pageCount;
+    }
+
+    public void setPageCount(Map<String, Integer> pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    public Map<String, Double> getTotalResponseTimes() {
+        return totalResponseTimes;
+    }
+
+    public void setTotalResponseTimes(Map<String, Double> totalResponseTimes) {
+        this.totalResponseTimes = totalResponseTimes;
+    }
+
+    public Map<String, Double> getMaxResponseTimes() {
+        return maxResponseTimes;
+    }
+
+    public void setMaxResponseTimes(Map<String, Double> maxResponseTimes) {
+        this.maxResponseTimes = maxResponseTimes;
+    }
+
+    public Map<String, Double> getAvgResponseTimes() {
+        return avgResponseTimes;
+    }
+
+    public void setAvgResponseTimes(Map<String, Double> avgResponseTimes) {
+        this.avgResponseTimes = avgResponseTimes;
+    }
+
+    public Map<String, Double> getMinResponseTimes() {
+        return minResponseTimes;
+    }
+
+    public void setMinResponseTimes(Map<String, Double> minResponseTimes) {
+        this.minResponseTimes = minResponseTimes;
+    }
+
+    public Map<String, HashMap<String, Integer>> getPageErrorCount() {
+        return pageErrorCount;
+    }
+
+    public void setPageErrorCount(Map<String, HashMap<String, Integer>> pageErrorCount) {
+        this.pageErrorCount = pageErrorCount;
+    }
+
+    public Map<String, String> getJsonDataByProvider() {
+        return jsonDataByProvider;
+    }
+
+    public void setJsonDataByProvider(Map<String, String> jsonDataByProvider) {
+        this.jsonDataByProvider = jsonDataByProvider;
+    }
+
+    public long getTotalHits() {
+        return totalHits;
+    }
+
+    public void setTotalHits(long totalHits) {
+        this.totalHits = totalHits;
+    }
+
+    public long getTotalPages() {
+        return totalPages;
+    }
+
+    public void setTotalPages(long totalPages) {
+        this.totalPages = totalPages;
+    }
+
+    public long getTotalErrors() {
+        return totalErrors;
+    }
+
+    public void setTotalErrors(long totalErrors) {
+        this.totalErrors = totalErrors;
+    }
+
+    public long getTotalIterations() {
+        return totalIterations;
+    }
+
+    public void setTotalIterations(long totalIterations) {
+        this.totalIterations = totalIterations;
+    }
+
+    public long getTotalBytesTransferred() {
+        return totalBytesTransferred;
+    }
+
+    public void setTotalBytesTransferred(long totalBytesTransferred) {
+        this.totalBytesTransferred = totalBytesTransferred;
+    }
+
+    public long getTotalBytesUploaded() {
+        return totalBytesUploaded;
+    }
+
+    public void setTotalBytesUploaded(long totalBytesUploaded) {
+        this.totalBytesUploaded = totalBytesUploaded;
+    }
+
+    public long getTotalBytesDownloaded() {
+        return totalBytesDownloaded;
+    }
+
+    public void setTotalBytesDownloaded(long totalBytesDownloaded) {
+        this.totalBytesDownloaded = totalBytesDownloaded;
+    }
+
+    public double getMaxPagesPerSecond() {
+        return maxPagesPerSecond;
+    }
+
+    public void setMaxPagesPerSecond(double maxPagesPerSecond) {
+        this.maxPagesPerSecond = maxPagesPerSecond;
+    }
+
+    public double getAvgPagesPerSecond() {
+        return avgPagesPerSecond;
+    }
+
+    public void setAvgPagesPerSecond(double avgPagesPerSecond) {
+        this.avgPagesPerSecond = avgPagesPerSecond;
+    }
+
+    public double getMinPagesPerSecond() {
+        return minPagesPerSecond;
+    }
+
+    public void setMinPagesPerSecond(double minPagesPerSecond) {
+        this.minPagesPerSecond = minPagesPerSecond;
+    }
+
+    public double getMaxHitsPerSecond() {
+        return maxHitsPerSecond;
+    }
+
+    public void setMaxHitsPerSecond(double maxHitsPerSecond) {
+        this.maxHitsPerSecond = maxHitsPerSecond;
+    }
+
+    public double getAvgHitsPerSecond() {
+        return avgHitsPerSecond;
+    }
+
+    public void setAvgHitsPerSecond(double avgHitsPerSecond) {
+        this.avgHitsPerSecond = avgHitsPerSecond;
+    }
+
+    public double getMinHitsPerSecond() {
+        return minHitsPerSecond;
+    }
+
+    public void setMinHitsPerSecond(double minHitsPerSecond) {
+        this.minHitsPerSecond = minHitsPerSecond;
+    }
+
+    public double getMaxBytesPerSecond() {
+        return maxBytesPerSecond;
+    }
+
+    public void setMaxBytesPerSecond(double maxBytesPerSecond) {
+        this.maxBytesPerSecond = maxBytesPerSecond;
+    }
+
+    public double getAvgBytesPerSecond() {
+        return avgBytesPerSecond;
+    }
+
+    public void setAvgBytesPerSecond(double avgBytesPerSecond) {
+        this.avgBytesPerSecond = avgBytesPerSecond;
+    }
+
+    public double getMinBytesPerSecond() {
+        return minBytesPerSecond;
+    }
+
+    public void setMinBytesPerSecond(double minBytesPerSecond) {
+        this.minBytesPerSecond = minBytesPerSecond;
+    }
+
+    public double getResponseTimeAvg() {
+        return responseTimeAvg;
+    }
+
+    public void setResponseTimeAvg(double responseTimeAvg) {
+        this.responseTimeAvg = responseTimeAvg;
+    }
+
+    public double getResponseTimeP90() {
+        return responseTimeP90;
+    }
+
+    public void setResponseTimeP90(double responseTimeP90) {
+        this.responseTimeP90 = responseTimeP90;
+    }
+
+    public double getResponseTimeP80() {
+        return responseTimeP80;
+    }
+
+    public void setResponseTimeP80(double responseTimeP80) {
+        this.responseTimeP80 = responseTimeP80;
+    }
+}


### PR DESCRIPTION
- Use Feign/Jackson instead of HttpClient/Gson. This should limit the transitive dependencies.
- Add method for obtaining test statistics as an object (separate from the HTML test report).
- Change usage slightly (separate projectId and scenarioId parameters).
