### PR TITLE
V1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: "java"
 apply plugin: "fatjar"
 apply plugin: "maven-publish"
 
-version "1.5"
+version "1.6"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Allow up to 3 polling failures when checking test status, in response to a user's report of socket timeouts when starting up a test. 
